### PR TITLE
API: glScissor

### DIFF
--- a/examples/basic.re
+++ b/examples/basic.re
@@ -170,6 +170,10 @@ let run = () => {
     glEnable(GL_DEPTH_TEST);
     glEnable(GL_BLEND);
 
+    /* Test scissor functionality */
+    /* glEnable(GL_SCISSOR_TEST); */
+    /* glScissor(200, 200, 200, 200); */
+
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     glDepthFunc(GL_LEQUAL);
 

--- a/src/gl_stubs.js
+++ b/src/gl_stubs.js
@@ -10,6 +10,11 @@ function caml_glViewport(x, y, width, height) {
     joo_global_object.gl.viewport(x, y , width, height);
 }
 
+// Provides: caml_glScissor
+function caml_glScissor(x, y, width, height) {
+    joo_global_object.gl.scissor(x, y , width, height);
+}
+
 // Provides: caml_glClearDepth
 function caml_glClearDepth(d) {
     joo_global_object.gl.clearDepth(d);

--- a/src/gl_wrapper.cpp
+++ b/src/gl_wrapper.cpp
@@ -45,6 +45,8 @@ extern "C" {
                 return GL_DEPTH_TEST;
             case 1:
                 return GL_BLEND;
+            case 2:
+                return GL_SCISSOR_TEST;
             default:
                 warn("Unexpected option for glEnable");
                 return 0;
@@ -177,6 +179,16 @@ extern "C" {
     CAMLprim value
     caml_glDisable(value vEnableOptions) {
         glDisable(variantToEnableOption(vEnableOptions));
+        return Val_unit;
+    }
+
+    CAMLprim value
+    caml_glScissor(value vX, value vY, value vWidth, value vHeight) {
+        int x = Int_val(vX);    
+        int y = Int_val(vY);
+        int width = Int_val(vWidth);
+        int height = Int_val(vHeight);
+        glScissor(x, y, width, height);
         return Val_unit;
     }
 

--- a/src/glfw.re
+++ b/src/glfw.re
@@ -228,12 +228,11 @@ external glClearDepth: float => unit = "caml_glClearDepth";
 external glCreateShader: shaderType => shader = "caml_glCreateShader";
 external glShaderSource: (shader, string) => unit = "caml_glShaderSource";
 
-external glViewport: (int, int, int, int) => unit = "caml_glViewport";
+[@noalloc] external glViewport: (int, int, int, int) => unit = "caml_glViewport";
+[@noalloc] external glScissor:  (int, int, int, int) => unit = "caml_glScissor"; 
 
 [@noalloc] external glEnable: enableOptions => unit = "caml_glEnable";
 [@noalloc] external glDisable: enableOptions => unit = "caml_glDisable";
-
-[@noalloc] external glScissor:  (int, int, int, int) => unit = "caml_glScissor"; 
 
 type depthFunctions =
   | GL_LEQUAL;

--- a/src/glfw.re
+++ b/src/glfw.re
@@ -230,12 +230,10 @@ external glShaderSource: (shader, string) => unit = "caml_glShaderSource";
 
 external glViewport: (int, int, int, int) => unit = "caml_glViewport";
 
-type enableOptions =
-  | GL_DEPTH_TEST
-  | GL_BLEND;
-
 [@noalloc] external glEnable: enableOptions => unit = "caml_glEnable";
 [@noalloc] external glDisable: enableOptions => unit = "caml_glDisable";
+
+[@noalloc] external glScissor:  (int, int, int, int) => unit = "caml_glScissor"; 
 
 type depthFunctions =
   | GL_LEQUAL;

--- a/src/glfw.rei
+++ b/src/glfw.rei
@@ -126,6 +126,7 @@ let glfwRenderLoop: (glfwRenderLoopCallback) => unit;
 let glClearColor: (float, float, float, float) => unit;
 let glClearDepth: float => unit;
 let glViewport: (int, int, int, int) => unit;
+let glScissor: (int, int, int, int) => unit;
 
 type shader;
 type shaderType =
@@ -156,8 +157,6 @@ type blendFunc =
   | GL_ONE_MINUS_SRC_ALPHA;
 
 let glBlendFunc: (blendFunc, blendFunc) => unit;
-
-type glScissor: (int, int, int, int) => unit;
 
 type program;
 

--- a/src/glfw.rei
+++ b/src/glfw.rei
@@ -141,10 +141,6 @@ let glShaderSource: (shader, string) => unit;
 let glCompileShader: shader => shaderCompilationResult;
 let glDeleteShader: shader => unit;
 
-type enableOptions =
-  | GL_DEPTH_TEST
-  | GL_BLEND;
-
 let glEnable: enableOptions => unit;
 let glDisable: enableOptions => unit;
 
@@ -160,6 +156,8 @@ type blendFunc =
   | GL_ONE_MINUS_SRC_ALPHA;
 
 let glBlendFunc: (blendFunc, blendFunc) => unit;
+
+type glScissor: (int, int, int, int) => unit;
 
 type program;
 

--- a/src/glfw_stubs.js
+++ b/src/glfw_stubs.js
@@ -364,6 +364,7 @@ function caml_glfwMakeContextCurrent(win) {
     joo_global_object.variantToEnableOption = {
         '0': gl.DEPTH_TEST,
         '1': gl.BLEND,
+        '2': gl.SCISSOR_TEST,
     };
 
     joo_global_object.variantToBlendFunc = {

--- a/src/glfw_types.re
+++ b/src/glfw_types.re
@@ -12,6 +12,10 @@ module Window = {
   };
 };
 
+type enableOptions =
+  | GL_DEPTH_TEST
+  | GL_BLEND
+  | GL_SCISSOR_TEST;
 
 type glfwFramebufferSizeCallback = (Window.t, int, int) => unit;
 type glfwWindowSizeCallback = (Window.t, int, int) => unit;


### PR DESCRIPTION
This adds the `glScissor` API for both WebGL and OpenGL strategies: https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glScissor.xml