### PR TITLE
Bugfix: Properly share types between `glfw.re` and `glfw.rei`.

### DIFF
--- a/src/glfw.re
+++ b/src/glfw.re
@@ -2,7 +2,7 @@ open Reglm;
 
 module Key = Glfw_key;
 
-open Glfw_types;
+include Glfw_types;
 
 /* GLFW */
 external glfwInit: unit => bool = "caml_glfwInit";

--- a/src/glfw.rei
+++ b/src/glfw.rei
@@ -2,7 +2,7 @@ open Reglm;
 
 module Key = Glfw_key;
 
-open Glfw_types;
+include (module type of Glfw_types);
 
 let glfwInit: unit => bool;
 let glfwCreateWindow: (int, int, string) => Window.t;


### PR DESCRIPTION
__Issue:__ I introduced a `glfw_types.re` to start sharing types between `glfw.re` and `glfw.rei`, so that we could de-dup some of that code.

__Defect:__ This wasn't done correctly - the right way is described [here](https://discuss.ocaml.org/t/avoiding-duplicated-definitions-in-module-implementation-and-interface/1546/3). This caused there to be errors accessing some of the shared members.

__Fix:__ Properly include the types in both `glfw.re` and `glfw.rei`.