### PR TITLE
Use devicePixelRatio to calculate canvas width and height

### DIFF
--- a/src/glfw_stubs.js
+++ b/src/glfw_stubs.js
@@ -122,8 +122,7 @@ function caml_glfwGetMonitorPos() {
 function caml_glfwGetFramebufferSize(w) {
     var width = w.canvas.width;
     var height = w.canvas.height;
-    var pixelRatio = joo_global_object.window.devicePixelRatio;
-    return [0, width * pixelRatio, height * pixelRatio];
+    return [0, width, height];
 }
 
 // Provides: caml_glfwDefaultWindowHints
@@ -173,8 +172,9 @@ function caml_glfwCreateWindow(width, height, title) {
     canvas.style.bottom = "0px";
     canvas.style.width = width.toString() + "px";
     canvas.style.height = height.toString() + "px";
-    canvas.width = width;
-    canvas.height = height;
+    var pixelRatio = joo_global_object.window.devicePixelRatio;
+    canvas.width = width * pixelRatio;
+    canvas.height = height * pixelRatio;
 
     joo_global_object._activeWindows = joo_global_object._activeWindows || [];
 
@@ -242,13 +242,13 @@ function caml_glfwCreateWindow(width, height, title) {
 
     var notifyResize = function () {
         if (w.isMaximized) {
-            canvas.width = canvas.offsetWidth;
-            canvas.height = canvas.offsetHeight;
-
             var pixelRatio = joo_global_object.window.devicePixelRatio;
 
+            canvas.width = canvas.offsetWidth * pixelRatio;
+            canvas.height = canvas.offsetHeight * pixelRatio;
+
             if (w.onSetFramebufferSize) {
-                w.onSetFramebufferSize(w, canvas.offsetWidth * pixelRatio, canvas.offsetHeight * pixelRatio);
+                w.onSetFramebufferSize(w, canvas.width, canvas.height);
             }
 
             if (w.onSetWindowSize) {
@@ -286,8 +286,9 @@ function caml_glfwSetWindowSize(w, width, height) {
     var canvas = w.canvas;
     canvas.style.width = width.toString() + "px";
     canvas.style.height = height.toString() + "px";
-    canvas.width = width;
-    canvas.height = height;
+    var pixelRatio = joo_global_object.window.devicePixelRatio;
+    canvas.width = width * pixelRatio;
+    canvas.height = height * pixelRatio;
 }
 
 // Provides: caml_glfwSetWindowTitle
@@ -340,11 +341,12 @@ function caml_glfwSetMouseButtonCallback(w, callback) {
 // Provides: caml_glfwMaximizeWindow
 function caml_glfwMaximizeWindow(w) {
     if (w && !w.isMaximized) {
+        var pixelRatio = joo_global_object.window.devicePixelRatio;
         var canvas = w.canvas;
         canvas.style.width = "100%";
         canvas.style.height = "100%";
-        canvas.width = canvas.offsetWidth;
-        canvas.height = canvas.offsetHeight;
+        canvas.width = canvas.offsetWidth * pixelRatio;
+        canvas.height = canvas.offsetHeight * pixelRatio;
         w.isMaximized = true;
         w._notifyResize();
     }


### PR DESCRIPTION
I noticed that the `canvas` created in the JS version of `reason-glfw` is not taking the pixel ratio into account. If the width is 800, both `canvas.style.width` and `canvas.width` are 800.

I was able to have the canvas rendering perfectly in a retina device by changing the value of `width` and `height` to double the pixels (so, `width` to 1600 and `height` to 1200 for a 800x600 window).

This is essentially what this PR does: calculate the canvas `width` and `height` based on the device pixel ratio. This also makes the canvas real size the same as the framebuffer size, so the values can be  returned from `caml_glfwGetFramebufferSize` without any extra modifications.

More info in https://support.unity3d.com/hc/en-us/articles/214948483-WebGL-looks-wrong-on-High-resolutions-Retina-.

Before this PR:

<img width="802" alt="image" src="https://user-images.githubusercontent.com/220424/50224496-58bce000-039e-11e9-92e4-82819c7658aa.png">

After:

<img width="802" alt="image" src="https://user-images.githubusercontent.com/220424/50224520-65413880-039e-11e9-852c-87619b492042.png">
