### PR TITLE
Add cursor style API

### DIFF
--- a/examples/basic.re
+++ b/examples/basic.re
@@ -39,6 +39,9 @@ let run = () => {
   glfwSetWindowSize(w, 800, 600);
   glfwSetWindowTitle(w, "reason-glfw example");
 
+  let cursor = glfwCreateStandardCursor(GLFW_CROSSHAIR_CURSOR);
+  glfwSetCursor(w, cursor);
+
   glViewport(0, 0, 800, 600);
 
   /* glfwSwapInterval sets the 'swap interval' - also known as vsync / vertical synchronization */

--- a/examples/basic.re
+++ b/examples/basic.re
@@ -39,8 +39,17 @@ let run = () => {
   glfwSetWindowSize(w, 800, 600);
   glfwSetWindowTitle(w, "reason-glfw example");
 
-  let cursor = glfwCreateStandardCursor(GLFW_CROSSHAIR_CURSOR);
-  glfwSetCursor(w, cursor);
+  let cursors = [|
+    glfwCreateStandardCursor(GLFW_ARROW_CURSOR),
+    glfwCreateStandardCursor(GLFW_IBEAM_CURSOR),
+    glfwCreateStandardCursor(GLFW_CROSSHAIR_CURSOR),
+    glfwCreateStandardCursor(GLFW_HAND_CURSOR),
+    glfwCreateStandardCursor(GLFW_HRESIZE_CURSOR),
+    glfwCreateStandardCursor(GLFW_VRESIZE_CURSOR),
+  |];
+  Random.self_init();
+  let cursor = Random.int(Array.length(cursors));
+  glfwSetCursor(w, cursors[cursor]);
 
   glViewport(0, 0, 800, 600);
 

--- a/src/glfw.re
+++ b/src/glfw.re
@@ -221,23 +221,13 @@ type glfwCursorShape =
   | GLFW_HAND_CURSOR
   | GLFW_HRESIZE_CURSOR
   | GLFW_VRESIZE_CURSOR;
-external caml_glfwCreateStandardCursor: glfwCursorShape => glfwCursor =
+
+external glfwCreateStandardCursor: glfwCursorShape => glfwCursor =
   "caml_glfwCreateStandardCursor";
-/*[@noalloc] external caml_glfwDestroyCursor: glfwCursor => unit =
-  "caml_glfwDestroyCursor";*/
-[@noalloc] external caml_glfwSetCursor: Window.t => glfwCursor => unit =
+[@noalloc] external glfwDestroyCursor: glfwCursor => unit =
+  "caml_glfwDestroyCursor";
+[@noalloc] external glfwSetCursor: Window.t => glfwCursor => unit =
   "caml_glfwSetCursor";
-
-let glfwCreateStandardCursor(shape) {
-  let cursor = caml_glfwCreateStandardCursor(shape);
-  /* We want this garbage collected, how can we do that?
-  Gc.finalise((c) => caml_glfwDestroyCursor(c), cursor);*/
-  cursor;
-}
-
-let glfwSetCursor(window, cursor) {
-  caml_glfwSetCursor(window, cursor);
-}
 
 /* GL */
 type shader;

--- a/src/glfw.re
+++ b/src/glfw.re
@@ -213,6 +213,32 @@ let glfwGetCursorPos = w => {
   v;
 };
 
+type glfwCursor;
+type glfwCursorShape =
+  | GLFW_ARROW_CURSOR
+  | GLFW_IBEAM_CURSOR
+  | GLFW_CROSSHAIR_CURSOR
+  | GLFW_HAND_CURSOR
+  | GLFW_HRESIZE_CURSOR
+  | GLFW_VRESIZE_CURSOR;
+external caml_glfwCreateStandardCursor: glfwCursorShape => glfwCursor =
+  "caml_glfwCreateStandardCursor";
+/*[@noalloc] external caml_glfwDestroyCursor: glfwCursor => unit =
+  "caml_glfwDestroyCursor";*/
+[@noalloc] external caml_glfwSetCursor: Window.t => glfwCursor => unit =
+  "caml_glfwSetCursor";
+
+let glfwCreateStandardCursor(shape) {
+  let cursor = caml_glfwCreateStandardCursor(shape);
+  /* We want this garbage collected, how can we do that?
+  Gc.finalise((c) => caml_glfwDestroyCursor(c), cursor);*/
+  cursor;
+}
+
+let glfwSetCursor(window, cursor) {
+  caml_glfwSetCursor(window, cursor);
+}
+
 /* GL */
 type shader;
 type shaderType =

--- a/src/glfw.rei
+++ b/src/glfw.rei
@@ -125,6 +125,7 @@ type glfwCursorShape =
   | GLFW_HRESIZE_CURSOR
   | GLFW_VRESIZE_CURSOR;
 let glfwCreateStandardCursor: (glfwCursorShape) => glfwCursor;
+let glfwDestroyCursor: (glfwCursor) => unit;
 let glfwSetCursor: (Window.t, glfwCursor) => unit;
 
 let printFrameBufferSize: Window.t => unit;

--- a/src/glfw.rei
+++ b/src/glfw.rei
@@ -116,6 +116,17 @@ type glfwCursorPos = {
 };
 let glfwGetCursorPos: Window.t => glfwCursorPos;
 
+type glfwCursor;
+type glfwCursorShape =
+  | GLFW_ARROW_CURSOR
+  | GLFW_IBEAM_CURSOR
+  | GLFW_CROSSHAIR_CURSOR
+  | GLFW_HAND_CURSOR
+  | GLFW_HRESIZE_CURSOR
+  | GLFW_VRESIZE_CURSOR;
+let glfwCreateStandardCursor: (glfwCursorShape) => glfwCursor;
+let glfwSetCursor: (Window.t, glfwCursor) => unit;
+
 let printFrameBufferSize: Window.t => unit;
 
 type glfwRenderLoopCallback = (float) => bool;

--- a/src/glfw_stubs.js
+++ b/src/glfw_stubs.js
@@ -91,6 +91,31 @@ function caml_glfwGetCursorPos(w) {
     return caml_js_to_array([joo_global_object._mouseState.x, joo_global_object._mouseState.y]);
 }
 
+// Provides; caml_glfwCreateStandardCursor
+function caml_glfwCreateStandardCursor(shape) {
+  switch (shape) {
+  case 0: return "default";
+  case 1: return "text";
+  case 2: return "crosshair";
+  case 3: return "pointer";
+  case 4: return "ew-resize";
+  case 5: return "ns-resize";
+  default:
+    joo_global_object.console.warn("Unsupported cursor shape.");
+    return "default";
+  }
+}
+
+// Provides: caml_glfwDestroyCursor
+function caml_glfwDestroyCursor(cursor) {
+  // no op
+}
+
+// Provides: caml_glfwSetCursor
+function caml_glfwSetCursor(window, cursor) {
+  window.canvas.style.cursor = cursor;
+}
+
 // Provides: caml_glfwGetTime_byte
 function caml_glfwGetTime_byte() {
     return (joo_global_object._time.offset + (Date.now() - joo_global_object._time.start)) / 1000;

--- a/src/glfw_stubs.js
+++ b/src/glfw_stubs.js
@@ -91,7 +91,7 @@ function caml_glfwGetCursorPos(w) {
     return caml_js_to_array([joo_global_object._mouseState.x, joo_global_object._mouseState.y]);
 }
 
-// Provides; caml_glfwCreateStandardCursor
+// Provides: caml_glfwCreateStandardCursor
 function caml_glfwCreateStandardCursor(shape) {
   switch (shape) {
   case 0: return "default";

--- a/src/glfw_wrapper.cpp
+++ b/src/glfw_wrapper.cpp
@@ -67,6 +67,23 @@ extern "C" {
         }
     }
 
+    int variantToCursorShape(value shape) {
+      switch(Int_val(shape)) {
+      case 0:
+        return GLFW_ARROW_CURSOR;
+      case 1:
+        return GLFW_IBEAM_CURSOR;
+      case 2:
+        return GLFW_CROSSHAIR_CURSOR;
+      case 3:
+        return GLFW_HAND_CURSOR;
+      case 4:
+        return GLFW_HRESIZE_CURSOR;
+      case 5:
+        return GLFW_VRESIZE_CURSOR;
+      }
+    }
+
     WindowInfo* getWindowInfoFromWindow(GLFWwindow *w) {
         WindowInfo *pInfo;
         for (int i = 0; i < sActiveWindowCount; i++) {
@@ -411,7 +428,7 @@ extern "C" {
     }
 
     CAMLprim value
-    caml_glfwGetVideoMode(value vMonitor) 
+    caml_glfwGetVideoMode(value vMonitor)
     {
         CAMLparam1(vMonitor);
         CAMLlocal1(ret);
@@ -493,6 +510,29 @@ extern "C" {
     }
 
     CAMLprim value
+    caml_glfwCreateStandardCursor(value shape) {
+      GLFWcursor *cursor;
+      cursor = glfwCreateStandardCursor(variantToCursorShape(shape));
+      return (value) cursor;
+    }
+
+    CAMLprim value
+    caml_glfwDestroyCursor(value cursor) {
+      GLFWcursor *cd = (GLFWcursor *) cursor;
+      glfwDestroyCursor(cd);
+      return Val_unit;
+    }
+
+    CAMLprim value
+    caml_glfwSetCursor(value window, value cursor) {
+      CAMLparam2(window, cursor);
+      WindowInfo *wd = (WindowInfo *) window;
+      GLFWcursor *cd = (GLFWcursor *) cursor;
+      glfwSetCursor(wd->pWindow, cd);
+      return Val_unit;
+    }
+
+    CAMLprim value
     caml_printFrameBufferSize(value window)
     {
         WindowInfo* wd = (WindowInfo*)window;
@@ -539,7 +579,7 @@ extern "C" {
     }
 
     CAMLprim value
-    caml_glfwPollEvents(value unit) 
+    caml_glfwPollEvents(value unit)
     {
         glfwPollEvents();
         return Val_unit;

--- a/src/glfw_wrapper.cpp
+++ b/src/glfw_wrapper.cpp
@@ -81,6 +81,9 @@ extern "C" {
         return GLFW_HRESIZE_CURSOR;
       case 5:
         return GLFW_VRESIZE_CURSOR;
+      default:
+        printf("Unexpected cursor shape.\n");
+        return 0;
       }
     }
 

--- a/src/glfw_wrapper.cpp
+++ b/src/glfw_wrapper.cpp
@@ -514,16 +514,18 @@ extern "C" {
 
     CAMLprim value
     caml_glfwCreateStandardCursor(value shape) {
+      CAMLparam1(shape);
       GLFWcursor *cursor;
       cursor = glfwCreateStandardCursor(variantToCursorShape(shape));
-      return (value) cursor;
+      CAMLreturn((value) cursor);
     }
 
     CAMLprim value
     caml_glfwDestroyCursor(value cursor) {
+      CAMLparam1(cursor);
       GLFWcursor *cd = (GLFWcursor *) cursor;
       glfwDestroyCursor(cd);
-      return Val_unit;
+      CAMLreturn(Val_unit);
     }
 
     CAMLprim value
@@ -532,7 +534,7 @@ extern "C" {
       WindowInfo *wd = (WindowInfo *) window;
       GLFWcursor *cd = (GLFWcursor *) cursor;
       glfwSetCursor(wd->pWindow, cd);
-      return Val_unit;
+      CAMLreturn(Val_unit);
     }
 
     CAMLprim value


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9326698/50433980-76f87380-08a9-11e9-8c6f-37a56c793851.png)

Fixes #66. I tested both the JS & native versions for a couple minutes and everything is looking good. One issue I didn't realize until testing though is that it `GLFW_HAND_CURSOR` seems to be the "grab" cursor in JS -- meaning there's no "pointer" cursor to use for buttons by default (see image). I currently used "pointer" in the JS version because that seems more important to me. Anyways, this may be a big annoyance since `glfwCreateCursor` takes an image, so we can't use the platform-specific cursors. That said, this may only be a weird thing on my system due to how I'm running the examples. It would be great if someone else could test this and confirm that they see the `GLFW_HAND_CURSOR` as "grab".