### PR TITLE
Add captureWindow

### DIFF
--- a/examples/basic.re
+++ b/examples/basic.re
@@ -319,8 +319,14 @@ let run = () => {
 
   /* glfwMaximizeWindow(w); */
 
+  let frame = ref(0);
   glfwRenderLoop(_t => {
     render();
+    if (frame^ mod 60 == 0) {
+      print_endline("Capturing!");
+      captureWindow(w, Printf.sprintf("scrot%d.tga", frame^));
+    };
+    frame := frame^ + 1;
 
     /* Run the GC so we can catch any GC-related crashes early! */
     Gc.full_major();

--- a/src/glfw.re
+++ b/src/glfw.re
@@ -381,3 +381,5 @@ external glDrawElements: (drawMode, int, glType, int) => unit =
   "caml_glDrawElements";
 
 external printFrameBufferSize: Window.t => unit = "caml_printFrameBufferSize";
+
+external captureWindow: (Window.t, string) => unit = "caml_captureWindow";

--- a/src/glfw.rei
+++ b/src/glfw.rei
@@ -271,3 +271,5 @@ type drawMode =
 
 let glDrawArrays: (drawMode, int, int) => unit;
 let glDrawElements: (drawMode, int, glType, int) => unit;
+
+let captureWindow: (Window.t, string) => unit;

--- a/src/glfw_stubs.js
+++ b/src/glfw_stubs.js
@@ -473,3 +473,8 @@ function caml_glfwSwapInterval(swapInterval) {
 function caml_glfwTerminate() {
     // no op
 }
+
+// Provides: caml_captureWindow
+function caml_captureWindow(vWindow, vFilename) {
+  throw "caml_captureWindow is not implemented in JS";
+}

--- a/src/glfw_wrapper.cpp
+++ b/src/glfw_wrapper.cpp
@@ -604,4 +604,38 @@ extern "C" {
         glfwTerminate();
         return Val_unit;
     }
+
+    // Based on https://github.com/Jba03/glReadPixels_example/blob/master/tga.cpp
+    // Is this the best place for this function?
+    CAMLprim value
+    caml_captureWindow(value vWindow, value vFilename) {
+      CAMLparam2(vWindow, vFilename);
+      WindowInfo *wd = (WindowInfo *) vWindow;
+      const char *filename = String_val(vFilename);
+
+      int width, height;
+
+      GLFWwindow *glfwWin = wd->pWindow;
+      glfwGetFramebufferSize(glfwWin, &width, &height);
+
+      uint8_t tga_header[12] = { 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
+                                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+      uint16_t header[3] = { (uint16_t) width, (uint16_t) height, 0x2018 };
+
+      // Array of 24-bit (3 byte) pixels of length width * height
+      size_t image_size = width * height * 3;
+      GLubyte *buffer = (GLubyte *) malloc(image_size * sizeof(GLubyte));
+
+      glReadPixels(0, 0, width, height, GL_RGB, GL_UNSIGNED_BYTE, buffer);
+
+      FILE *fd = fopen(filename, "wb");
+      fwrite(tga_header, 1, 12, fd);
+      fwrite(header, 2, 3, fd);
+      fwrite(buffer, sizeof(GLubyte), image_size, fd);
+      fclose(fd);
+
+      free(buffer);
+
+      CAMLreturn(Val_unit);
+    }
 }


### PR DESCRIPTION
This PR adds `Reglfw.Glfw.captureWindow: (Window.t, string) => unit` which takes the contents of the current window and saves it to a TGA file. Currently, the stub for this method is located in `glfw_wrapper.cpp` but that may not be the best logical place for it. It also *isn't* implemented in JS. This could be added using the `GL.readPixels()` call in the browser (note: this gives us far less control over the desired format that the real `glReadPixels()`) and outputting the TGA file to a data URI, I just haven't put in the work for that yet.

The primary motivation for this PR is for testing apps written using reason-glfw, since it allows us to capture the window at a certain frame (see the example, where it captures it every 60 frames). This can be used for UI regression tests as discussed in [revery-ui/revery#156](https://github.com/revery-ui/revery/issues/156). For example, we provide a reference image for frame X and then take a screenshot at frame X when the program runs using this API. The two images are then diffed in a shell script (we can use `magick compare` for this), and if they don't match they're uploaded to some image host where we can compare the two.

Note for some further discussion on this API: I was originally going to implement raw calls to `glReadPixels` but eventually decided against this for the following reasons:
* We would need an image buffer to work with, so we'd have to expose some `malloc` functionality to OCaml. The approach I thought would work best would be to create an image object, but I thought that might be confusing because we wouldn't be able to utilize any of stb_image for that.
* `glReadPixels` is pretty different in JS, since it doesn't take any parameters and doesn't write into a buffer of any kind. It would also be weird to break this process up into multiple functions because they would have differing levels of JS compatibility along the way.
* It would provide a lot more room for user error, since the user would have to pick an image format/type for `glReadPixels` and then find a matching format to use for the TGA format.