### PR TITLE
Fix glReadPixels

### DIFF
--- a/src/gl_stubs.js
+++ b/src/gl_stubs.js
@@ -287,5 +287,21 @@ function caml_glReadPixels_bytecode(x, y, width, height, vFormat, vType, data) {
   }
 
   joo_global_object.gl.readPixels(x, y, width, height, format, type, data);
+
+  // If we're on a little-endian system, the R/B channels are swapped
+  // So let's determine endianness...
+  var marker = new ArrayBuffer(4);
+  var u32view = new Uint32Array(marker);
+  u32view[0] = 0x12345678;
+  var u8view = new Uint8Array(marker);
+  if (u8view[0] == 0x78 && type == joo_global_object.gl.UNSIGNED_BYTE) {
+    // We are little-endian. Onto the swap...
+    var numChannels = format == joo_global_object.gl.RGBA ? 4 : 3;
+    for (var i = 0; i < width * height * numChannels; i += numChannels) {
+      var tmp = data[i];
+      data[i] = data[i+2];
+      data[i+2] = tmp;
+    }
+  }
 }
 

--- a/src/gl_wrapper.cpp
+++ b/src/gl_wrapper.cpp
@@ -619,6 +619,19 @@ extern "C" {
 
       glReadPixels(x, y, width, height, format, type, data);
 
+      // If we're on a little-endian system, the R/B channels are swapped
+      // So let's determine endianness...
+      unsigned int marker = 0x12345678;
+      if (*(char *) &marker == 0x78 && type == GL_UNSIGNED_BYTE) {
+        // We are little-endian. Onto the swap...
+        int numChannels = format == GL_RGBA ? 4 : 3;
+        for (int i = 0; i < width * height * numChannels; i += numChannels) {
+          uint8_t tmp = *((uint8_t *) data + i);
+          *((uint8_t *) data + i) = *((uint8_t *) data + i + 2);
+          *((uint8_t *) data + i + 2) = tmp;
+        }
+      }
+
       CAMLreturn(Val_unit);
     }
 
@@ -642,6 +655,19 @@ extern "C" {
       void *data = (void *) vData;
 
       glReadPixels(x, y, width, height, format, type, data);
+
+      // If we're on a little-endian system, the R/B channels are swapped
+      // So let's determine endianness...
+      unsigned int marker = 0x12345678;
+      if (*(char *) &marker == 0x78 && type == GL_UNSIGNED_BYTE) {
+        // We are little-endian. Onto the swap...
+        int numChannels = format == GL_RGBA ? 4 : 3;
+        for (int i = 0; i < width * height * numChannels; i += numChannels) {
+          uint8_t tmp = *((uint8_t *) data + i);
+          *((uint8_t *) data + i) = *((uint8_t *) data + i + 2);
+          *((uint8_t *) data + i + 2) = tmp;
+        }
+      }
 
       CAMLreturn(Val_unit);
     }

--- a/src/image_stubs.js
+++ b/src/image_stubs.js
@@ -54,8 +54,7 @@ function caml_saveImage(image, path) {
   var tga_header = [0, 0, 2, 0, 0, 0,
                     0, 0, 0, 0, 0, 0];
   var bitsPerPixel = 8 * image.numChannels * image.channelSize;
-  var imageDescriptor = image.numChannels > 3 ? 0x28 : 0x20;
-  var header = [image.width, image.height, (imageDescriptor << 8) | bitsPerPixel];
+  var header = [image.width, image.height, bitsPerPixel];
 
   // Copy in all the data to the new buffer
   var bufferIndex = 0;

--- a/src/reglfw_image.cpp
+++ b/src/reglfw_image.cpp
@@ -49,12 +49,10 @@ extern "C" {
       uint8_t tga_header[12] = { 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
       uint8_t bitsPerPixel = 8 * image->numChannels * image->channelSize;
       // See http://www.paulbourke.net/dataformats/tga/
-      uint8_t imageDescriptor =
-        image->numChannels > 3 ? 0x28 : 0x20;
       uint16_t header[3] = {
         (uint16_t) image->width,
         (uint16_t) image->height,
-        (uint16_t) (((uint16_t) imageDescriptor << 8) | (uint16_t) bitsPerPixel)
+        (uint16_t) bitsPerPixel // Image descriptor = 0
       };
 
       const char *path = String_val(vPath);


### PR DESCRIPTION
Addresses the issue I brought up in https://github.com/revery-ui/revery/issues/185. Again, this is one of those places where I feel like I sort of had to employ a hack, but it works on my test inputs (easiest way to verify that this is working is to change the glClearColor to red or blue).

Basic description of what I changed:
* I was previously setting the image descriptor byte based on what some example code was doing. Not sure why, but this swapped the y-axis so now I just set the image descriptor byte to 0 (which should work according to the TGA spec).
* I was previously copying in the raw pixel array as returned by glReadPixels. This would break if you used GL_UNSIGNED_BYTE on a little-endian system, so instead I'm swapping the red/blue channels in the glReadPixels stubs (both native & js).