### PR TITLE
API: glfwGetWindowSize

### DIFF
--- a/src/glfw.re
+++ b/src/glfw.re
@@ -20,6 +20,8 @@ external glfwSetWindowSize: (Window.t, int, int) => unit =
 [@noalloc]
 external glfwSetWindowPos: (Window.t, int, int) => unit =
   "caml_glfwSetWindowPos";
+external glfwGetWindowSize: Window.t => Window.windowSize =
+  "caml_glfwGetWindowSize";
 external glfwGetFramebufferSize: Window.t => Window.frameBufferSize =
   "caml_glfwGetFramebufferSize";
 [@noalloc] external glfwShowWindow: Window.t => unit = "caml_glfwShowWindow";

--- a/src/glfw.rei
+++ b/src/glfw.rei
@@ -14,6 +14,7 @@ let glfwSwapBuffers: Window.t => unit;
 let glfwSetWindowPos: (Window.t, int, int) => unit;
 let glfwSetWindowSize: (Window.t, int, int) => unit;
 let glfwGetFramebufferSize: (Window.t) => Window.frameBufferSize;
+let glfwGetWindowSize: (Window.t) => Window.windowSize;
 let glfwMaximizeWindow: (Window.t) => unit;
 let glfwSetWindowTitle: (Window.t, string) => unit;
 let glfwShowWindow: (Window.t) => unit;

--- a/src/glfw_stubs.js
+++ b/src/glfw_stubs.js
@@ -142,12 +142,20 @@ function caml_glfwGetVideoMode() {
 function caml_glfwGetMonitorPos() {
     return [0, 0, 0];
 };
+//
+// Provides: caml_glfwGetWindowSize
+function caml_glfwGetWindowSize(w) {
+    var pixelRatio = joo_global_object.window.devicePixelRatio;
+    var width = w.canvas.width;
+    var height = w.canvas.height;
+    return [0, width, height];
+}
 
 // Provides: caml_glfwGetFramebufferSize
 function caml_glfwGetFramebufferSize(w) {
     var pixelRatio = joo_global_object.window.devicePixelRatio;
-    var width = w.canvas.width / pixelRatio;
-    var height = w.canvas.height / pixelRatio;
+    var width = w.canvas.width * pixelRatio;
+    var height = w.canvas.height * pixelRatio;
     return [0, width, height];
 }
 

--- a/src/glfw_stubs.js
+++ b/src/glfw_stubs.js
@@ -146,16 +146,16 @@ function caml_glfwGetMonitorPos() {
 // Provides: caml_glfwGetWindowSize
 function caml_glfwGetWindowSize(w) {
     var pixelRatio = joo_global_object.window.devicePixelRatio;
-    var width = w.canvas.width;
-    var height = w.canvas.height;
+    var width = w.canvas.width / pixelRatio;
+    var height = w.canvas.height / pixelRatio;
     return [0, width, height];
 }
 
 // Provides: caml_glfwGetFramebufferSize
 function caml_glfwGetFramebufferSize(w) {
     var pixelRatio = joo_global_object.window.devicePixelRatio;
-    var width = w.canvas.width * pixelRatio;
-    var height = w.canvas.height * pixelRatio;
+    var width = w.canvas.width;
+    var height = w.canvas.height;
     return [0, width, height];
 }
 

--- a/src/glfw_wrapper.cpp
+++ b/src/glfw_wrapper.cpp
@@ -463,6 +463,23 @@ extern "C" {
     }
 
     CAMLprim value
+    caml_glfwGetWindowSize(value vWindow)
+    {
+        CAMLparam1(vWindow);
+        CAMLlocal1(ret);
+        WindowInfo* pWindowInfo = (WindowInfo *)vWindow;
+
+        int width, height;
+        glfwGetWindowSize(pWindowInfo->pWindow, &width, &height);
+
+        ret = caml_alloc(2, 0);
+        Store_field(ret, 0, Val_int(width));
+        Store_field(ret, 1, Val_int(height));
+
+        CAMLreturn(ret);
+    }
+
+    CAMLprim value
     caml_glfwGetMonitorPos(value vMonitor) {
         CAMLparam1(vMonitor);
         CAMLlocal1(ret);


### PR DESCRIPTION
- [x] Validate revery on high-DPI screens with this change - validated both WebGL and native in high-DPI