### PR TITLE
Add errors to caml_glfwCreateStandardCursor

### DIFF
--- a/src/glfw_wrapper.cpp
+++ b/src/glfw_wrapper.cpp
@@ -5,6 +5,7 @@
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/callback.h>
+#include <caml/fail.h>
 
 #include <glad/glad.h>
 
@@ -534,7 +535,11 @@ extern "C" {
       CAMLparam1(shape);
       GLFWcursor *cursor;
       cursor = glfwCreateStandardCursor(variantToCursorShape(shape));
-      CAMLreturn((value) cursor);
+      if (cursor == NULL) { // If there was an error
+        caml_failwith("Error thrown while creating GLFW cursor. Make sure to init GLFW before creating a cursor");
+      } else {
+        CAMLreturn((value) cursor);
+      }
     }
 
     CAMLprim value


### PR DESCRIPTION
This addresses #73. Just throws a simple error when the cursor can't be created in glfw. Not sure if we want to have just an exception here (brought up my argument for this in #73) or if we would prefer to return `option(glfwCursor)`