### PR TITLE
Bugfix: Event delegation not working correctly for multiple windows

### DIFF
--- a/src/glfw_wrapper.cpp
+++ b/src/glfw_wrapper.cpp
@@ -17,13 +17,10 @@
 
 extern "C" {
 
-static int _nextWindowId = 0;
-
 #define Val_none Val_int(0)
 #define Some_val(v) Field(v,0)
 
     struct WindowInfo {
-        int id;
         GLFWwindow* pWindow;
         bool isDestroyed;
         value vSetFramebufferSizeCallback;
@@ -233,12 +230,7 @@ static int _nextWindowId = 0;
         wd = glfwCreateWindow(w, h, s, NULL, sharedWindow);
       };
 
-
-      int id = _nextWindowId;
-      _nextWindowId++;
-
       struct WindowInfo* pWindowInfo = (WindowInfo *)malloc(sizeof(WindowInfo));
-      pWindowInfo->id = id;
       pWindowInfo->pWindow = wd;
       pWindowInfo->isDestroyed = false;
       pWindowInfo->vSetFramebufferSizeCallback = Val_unit;

--- a/src/glfw_wrapper.cpp
+++ b/src/glfw_wrapper.cpp
@@ -15,13 +15,15 @@
 
 #include <reglfw_image.h>
 
-
 extern "C" {
+
+static int _nextWindowId = 0;
 
 #define Val_none Val_int(0)
 #define Some_val(v) Field(v,0)
 
     struct WindowInfo {
+        int id;
         GLFWwindow* pWindow;
         bool isDestroyed;
         value vSetFramebufferSizeCallback;
@@ -95,7 +97,7 @@ extern "C" {
     WindowInfo* getWindowInfoFromWindow(GLFWwindow *w) {
         WindowInfo *pInfo;
         for (int i = 0; i < sActiveWindowCount; i++) {
-            if (sActiveWindows[i] && sActiveWindows[i]->pWindow) {
+            if (sActiveWindows[i] && sActiveWindows[i]->pWindow && sActiveWindows[i]->pWindow == w) {
                 pInfo = sActiveWindows[i];
             }
         }
@@ -232,7 +234,11 @@ extern "C" {
       };
 
 
+      int id = _nextWindowId;
+      _nextWindowId++;
+
       struct WindowInfo* pWindowInfo = (WindowInfo *)malloc(sizeof(WindowInfo));
+      pWindowInfo->id = id;
       pWindowInfo->pWindow = wd;
       pWindowInfo->isDestroyed = false;
       pWindowInfo->vSetFramebufferSizeCallback = Val_unit;


### PR DESCRIPTION
__Issue:__ The events coming from the window - like resize, etc - will always be sent to the _newest_ Window created - even if they came from another, previously created Window. In effect, the new Window steals all the events.

__Defect:__ The logic we use for mapping the `WindowInfo` pointer to the underying `glfwWindow` was incorrect - we'd always pick the latest `WindowInfo` instead of checking for the one that matches.

__Fix:__ Correct the conditional. Longer term, we should look at removing this mapping function entirely - it turns out there is a better way using `glfwSetWindowUserPointer`/`glfwGetWindowUserPointer`. Logged #84 to track this.