### PR TITLE
Feature/add get monitor size

### DIFF
--- a/src/glfw.re
+++ b/src/glfw.re
@@ -95,6 +95,11 @@ module Monitor = {
     x: int,
     y: int,
   };
+
+  type dimensions = {
+    width: int,
+    height: int,
+  };
 };
 
 module VideoMode = {
@@ -110,7 +115,7 @@ external glfwGetPrimaryMonitor: unit => Monitor.t =
 external glfwGetVideoMode: Monitor.t => VideoMode.t = "caml_glfwGetVideoMode";
 external glfwGetMonitorPos: Monitor.t => Monitor.position =
   "caml_glfwGetMonitorPos";
-external glfwGetMonitorPhysicalSize: Monitor.t =
+external glfwGetMonitorPhysicalSize: Monitor.t => Monitor.dimensions =
   "caml_glfwGetMonitorPhysicalSize";
 
 type windowHint =

--- a/src/glfw.re
+++ b/src/glfw.re
@@ -41,7 +41,9 @@ external glfwGetTime: unit => [@unboxed] float =
 external glfwSetTime: ([@unboxed] float) => unit =
   "caml_glfwSetTime_byte" "caml_glfwSetTime";
 
-[@noalloc] external glfwGetNativeWindow: Window.t => NativeWindow.t = "caml_glfwGetNativeWindow";
+[@noalloc]
+external glfwGetNativeWindow: Window.t => NativeWindow.t =
+  "caml_glfwGetNativeWindow";
 
 module Modifier = {
   type t = int;
@@ -108,6 +110,8 @@ external glfwGetPrimaryMonitor: unit => Monitor.t =
 external glfwGetVideoMode: Monitor.t => VideoMode.t = "caml_glfwGetVideoMode";
 external glfwGetMonitorPos: Monitor.t => Monitor.position =
   "caml_glfwGetMonitorPos";
+external glfwGetMonitorPhysicalSize: Monitor.t =
+  "caml_glfwGetMonitorPhysicalSize";
 
 type windowHint =
   | GLFW_RESIZABLE

--- a/src/glfw.rei
+++ b/src/glfw.rei
@@ -59,6 +59,11 @@ module Monitor: {
     x: int,
     y: int,
   };
+
+  type dimensions = {
+    width: int,
+    height: int,
+  };
 };
 
 module VideoMode: {
@@ -71,6 +76,7 @@ module VideoMode: {
 let glfwGetPrimaryMonitor: unit => Monitor.t;
 let glfwGetVideoMode: Monitor.t => VideoMode.t;
 let glfwGetMonitorPos: Monitor.t => Monitor.position;
+let glfwGetMonitorPhysicalSize: Monitor.t => Monitor.dimensions;
 
 type windowHint =
   | GLFW_RESIZABLE

--- a/src/glfw_stubs.js
+++ b/src/glfw_stubs.js
@@ -142,7 +142,12 @@ function caml_glfwGetVideoMode() {
 function caml_glfwGetMonitorPos() {
     return [0, 0, 0];
 };
-//
+
+// Provides: caml_glfwGetMonitorPhysicalSize
+function caml_glfwGetMonitorPhysicalSize() {
+  return [0, 0, 0];
+};
+
 // Provides: caml_glfwGetWindowSize
 function caml_glfwGetWindowSize(w) {
     var pixelRatio = joo_global_object.window.devicePixelRatio;

--- a/src/glfw_stubs.js
+++ b/src/glfw_stubs.js
@@ -146,8 +146,8 @@ function caml_glfwGetMonitorPos() {
 // Provides: caml_glfwGetMonitorPhysicalSize
 function caml_glfwGetMonitorPhysicalSize() {
   const dpi = window.devicePixelRatio * 96;
-  const widthMM = window.innerWidth / (25.4 * dpi)
-  const heightMM = window.innerHeight / (25.4 * dpi)
+  const widthMM = window.innerWidth / (25.4 * dpi);
+  const heightMM = window.innerHeight / (25.4 * dpi);
   return [0, widthMM, heightMM];
 };
 

--- a/src/glfw_stubs.js
+++ b/src/glfw_stubs.js
@@ -145,9 +145,10 @@ function caml_glfwGetMonitorPos() {
 
 // Provides: caml_glfwGetMonitorPhysicalSize
 function caml_glfwGetMonitorPhysicalSize() {
-  const dpi = window.devicePixelRatio * 96;
-  const widthMM = window.innerWidth / (25.4 * dpi);
-  const heightMM = window.innerHeight / (25.4 * dpi);
+  var win = joo_global_object.window;
+  var dpi = win.devicePixelRatio * 96;
+  var widthMM = win.innerWidth / (25.4 * dpi);
+  var heightMM = win.innerHeight / (25.4 * dpi);
   return [0, widthMM, heightMM];
 };
 

--- a/src/glfw_stubs.js
+++ b/src/glfw_stubs.js
@@ -146,8 +146,8 @@ function caml_glfwGetMonitorPos() {
 // Provides: caml_glfwGetMonitorPhysicalSize
 function caml_glfwGetMonitorPhysicalSize() {
   const dpi = window.devicePixelRatio * 96;
-  const widthMM = window.innerWidth / (25.4 * 96 * window.devicePixelRatio)
-  const heightMM = window.innerHeight / (25.4 * 96 * window.devicePixelRatio)
+  const widthMM = window.innerWidth / (25.4 * dpi)
+  const heightMM = window.innerHeight / (25.4 * dpi)
   return [0, widthMM, heightMM];
 };
 

--- a/src/glfw_stubs.js
+++ b/src/glfw_stubs.js
@@ -145,7 +145,10 @@ function caml_glfwGetMonitorPos() {
 
 // Provides: caml_glfwGetMonitorPhysicalSize
 function caml_glfwGetMonitorPhysicalSize() {
-  return [0, 0, 0];
+  const dpi = window.devicePixelRatio * 96;
+  const widthMM = window.innerWidth / (25.4 * 96 * window.devicePixelRatio)
+  const heightMM = window.innerHeight / (25.4 * 96 * window.devicePixelRatio)
+  return [0, widthMM, heightMM];
 };
 
 // Provides: caml_glfwGetWindowSize

--- a/src/glfw_wrapper.cpp
+++ b/src/glfw_wrapper.cpp
@@ -554,7 +554,7 @@ extern "C" {
 
         ret = caml_alloc(2, 0);
         Store_field(ret, 0, Val_int(widthMM));
-        Store_field(ret, 0, Val_int(heightMM));
+        Store_field(ret, 1, Val_int(heightMM));
 
         CAMLreturn(ret);
     }

--- a/src/glfw_wrapper.cpp
+++ b/src/glfw_wrapper.cpp
@@ -543,18 +543,18 @@ extern "C" {
     }
 
     CAMLprim value
-    caml_glfwGetPrimaryMonitorPhysicalSize(value vMonitor)
+    caml_glfwGetMonitorPhysicalSize(value vMonitor)
     {
         CAMLparam1(vMonitor);
-        CAMLlocal1(size)
-        GLFWmonitor* pMonitor = (GLFWmonitor*)vMonitor;
+        CAMLlocal1(ret);
+        GLFWmonitor* zMonitor = (GLFWmonitor*)vMonitor;
 
         int widthMM, heightMM;
-        glfwGetMonitorPhysicalSize(monitor, &widthMM, &heightMM);
+        glfwGetMonitorPhysicalSize(zMonitor, &widthMM, &heightMM);
 
-        ret = caml_alloc(2, 0)
-        Store_field(size, 0, Val_int(widthMM));
-        Store_field(size, 0, Val_int(heightMM));
+        ret = caml_alloc(2, 0);
+        Store_field(ret, 0, Val_int(widthMM));
+        Store_field(ret, 0, Val_int(heightMM));
 
         CAMLreturn(ret);
     }

--- a/src/glfw_wrapper.cpp
+++ b/src/glfw_wrapper.cpp
@@ -543,6 +543,23 @@ extern "C" {
     }
 
     CAMLprim value
+    caml_glfwGetPrimaryMonitorPhysicalSize(value vMonitor)
+    {
+        CAMLparam1(vMonitor);
+        CAMLlocal1(size)
+        GLFWmonitor* pMonitor = (GLFWmonitor*)vMonitor;
+
+        int widthMM, heightMM;
+        glfwGetMonitorPhysicalSize(monitor, &widthMM, &heightMM);
+
+        ret = caml_alloc(2, 0)
+        Store_field(size, 0, Val_int(widthMM));
+        Store_field(size, 0, Val_int(heightMM));
+
+        CAMLreturn(ret);
+    }
+
+    CAMLprim value
     caml_glfwSetCursorPosCallback(value vWindow, value vCallback) {
         CAMLparam2(vWindow, vCallback);
 


### PR DESCRIPTION
this relates to revery-ui/revery#226, it adds `glfwGetMonitorPhysicalSize` so we query for a monitors dimensions and use this eventually to calculate the dpi of the screen

### issues (Resolved)
~~I'm currently getting v. weird numbers for my monitor size, looking at the [docs](https://www.glfw.org/docs/latest/group__monitor.html#ga7d8bffc6c55539286a6bd20d32a8d7ea) that might be a system issue although when I run
` xrandr | grep ' connected'` I get 
```
eDP-1 connected primary 3840x2160+0+0 (normal left inverted right x axis y axis) 344mm x 194mm
```
The `mm` values also seem weird but are actually different from what the glfw function returns~~

cc @bryphe 
