### PR TITLE
Fix undefined references when building on Linux

### DIFF
--- a/config/discover.ml
+++ b/config/discover.ml
@@ -41,6 +41,8 @@ let flags =
         @ cclib("-lX11")
         @ cclib("-lXxf86vm")
         @ cclib("-lXrandr")
+        @ cclib("-lXinerama")
+        @ cclib("-lXcursor")
         @ cclib("-lpthread")
         @ cclib("-lXi")
     | _ -> []


### PR DESCRIPTION
There were couple of link flags missing when building this library.
glfw requires more X libraries to be linked into the resulting binary.
The missing ones were xinerama and xcursor.

You can see more info [here](https://stackoverflow.com/questions/29459664/undefined-references-compiling-opengl-glfw-glew-on-ubuntug).