### PR TITLE
Performance: Add [@noalloc]

### DIFF
--- a/src/glfw.re
+++ b/src/glfw.re
@@ -305,32 +305,46 @@ type shaderLinkResult =
 external glLinkProgram: program => shaderLinkResult = "caml_glLinkProgram";
 
 type attribLocation;
+[@noalloc]
 external glGetAttribLocation: (program, string) => attribLocation =
   "caml_glGetAttribLocation";
 
 type uniformLocation;
+[@noalloc]
 external glGetUniformLocation: (program, string) => uniformLocation =
   "caml_glGetUniformLocation";
 
+[@noalloc]
 external glUniform1f: (uniformLocation, float) => unit = "caml_glUniform1f";
+[@noalloc]
 external glUniform2f: (uniformLocation, float, float) => unit =
   "caml_glUniform2f";
+[@noalloc]
 external glUniform3f: (uniformLocation, float, float, float) => unit =
   "caml_glUniform3f";
+[@noalloc]
 external glUniform4f: (uniformLocation, float, float, float, float) => unit =
   "caml_glUniform4f";
 
+[@noalloc]
 external glUniform1i: (uniformLocation, int) => unit = "caml_glUniform1i";
+[@noalloc]
 external glUniform2i: (uniformLocation, int, int) => unit = "caml_glUniform2i";
+[@noalloc]
 external glUniform3i: (uniformLocation, int, int, int) => unit =
   "caml_glUniform3i";
+[@noalloc]
 external glUniform4i: (uniformLocation, int, int, int, int) => unit =
   "caml_glUniform4i";
 
+[@noalloc]
 external glUniform2fv: (uniformLocation, Vec2.t) => unit = "caml_glUniform2fv";
+[@noalloc]
 external glUniform3fv: (uniformLocation, Vec3.t) => unit = "caml_glUniform3fv";
+[@noalloc]
 external glUniform4fv: (uniformLocation, Vec4.t) => unit = "caml_glUniform4fv";
 
+[@noalloc]
 external glUniformMatrix4fv: (uniformLocation, Mat4.t) => unit =
   "caml_glUniformMatrix4fv";
 
@@ -338,6 +352,7 @@ type pixelAlignmentParameter =
   | GL_PACK_ALIGNMENT
   | GL_UNPACK_ALIGNMENT;
 
+[@noalloc]
 external glPixelStorei: (pixelAlignmentParameter, int) => unit =
   "caml_glPixelStorei";
 
@@ -368,12 +383,16 @@ type glType =
   | GL_UNSIGNED_SHORT_4_4_4_4
   | GL_UNSIGNED_SHORT_5_5_5_1;
 
+[@noallooc]
 external glCreateTexture: unit => texture = "caml_glCreateTexture";
+[@noalloc]
 external glBindTexture: (textureType, texture) => unit = "caml_glBindTexture";
+[@noalloc]
 external glTexParameteri:
   (textureType, textureParameter, textureParameterValue) => unit =
   "caml_glTexParameteri";
 external glTexImage2D: (textureType, Image.t) => unit = "caml_glTexImage2D";
+[@noalloc]
 external glGenerateMipmap: textureType => unit = "caml_glGenerateMipmap";
 
 type bufferType =
@@ -381,19 +400,25 @@ type bufferType =
   | GL_ELEMENT_ARRAY_BUFFER;
 
 type buffer;
+[@noalloc]
 external glCreateBuffer: unit => buffer = "caml_glCreateBuffer";
+[@noalloc]
 external glBindBuffer: (bufferType, buffer) => unit = "caml_glBindBuffer";
+[@noalloc]
 external glUnbindBuffer: bufferType => unit = "caml_glUnbindBuffer";
 
 type drawType =
   | GL_STATIC_DRAW;
 
+[@noalloc]
 external glBufferData:
   (bufferType, Bigarray.Array1.t('a, 'b, Bigarray.c_layout), drawType) => unit =
   "caml_glBufferData";
 
+[@noalloc]
 external glVertexAttribPointer: (attribLocation, int, glType, bool) => unit =
   "caml_glVertexAttribPointer";
+[@noalloc]
 external glEnableVertexAttribArray: attribLocation => unit =
   "caml_glEnableVertexAttribArray";
 
@@ -401,7 +426,9 @@ type drawMode =
   | GL_TRIANGLES
   | GL_TRIANGLE_STRIP;
 
+[@noalloc]
 external glDrawArrays: (drawMode, int, int) => unit = "caml_glDrawArrays";
+[@noalloc]
 external glDrawElements: (drawMode, int, glType, int) => unit =
   "caml_glDrawElements";
 


### PR DESCRIPTION
Add the `noalloc` instruction to improve performance across C FFI calls, where it makes sense.