### PR TITLE
Performance: Release runtime during glfwSwapBuffers

### DIFF
--- a/src/glfw.re
+++ b/src/glfw.re
@@ -13,8 +13,10 @@ external glfwMakeContextCurrent: Window.t => unit =
   "caml_glfwMakeContextCurrent";
 external glfwWindowShouldClose: Window.t => bool =
   "caml_glfwWindowShouldClose";
+
 external glfwPollEvents: unit => unit = "caml_glfwPollEvents";
 external glfwTerminate: unit => unit = "caml_glfwTerminate";
+[@noalloc]
 external glfwSwapBuffers: Window.t => unit = "caml_glfwSwapBuffers";
 external glfwSetWindowSize: (Window.t, int, int) => unit =
   "caml_glfwSetWindowSize";

--- a/src/glfw_wrapper.cpp
+++ b/src/glfw_wrapper.cpp
@@ -6,6 +6,7 @@
 #include <caml/alloc.h>
 #include <caml/callback.h>
 #include <caml/fail.h>
+#include <caml/threads.h>
 
 #include <glad/glad.h>
 
@@ -681,7 +682,7 @@ extern "C" {
     caml_glfwSwapBuffers(value window)
     {
         WindowInfo *wd = (WindowInfo*)window;
-        GLFWWindow *pWindow = wd->pWindow;
+        GLFWwindow *pWindow = wd->pWindow;
         caml_release_runtime_system();
         glfwSwapBuffers(pWindow);
         caml_acquire_runtime_system();

--- a/src/glfw_wrapper.cpp
+++ b/src/glfw_wrapper.cpp
@@ -681,7 +681,10 @@ extern "C" {
     caml_glfwSwapBuffers(value window)
     {
         WindowInfo *wd = (WindowInfo*)window;
-        glfwSwapBuffers(wd->pWindow);
+        GLFWWindow *pWindow = wd->pWindow;
+        caml_release_runtime_system();
+        glfwSwapBuffers(pWindow);
+        caml_acquire_runtime_system();
         return Val_unit;
     }
 


### PR DESCRIPTION
A detailed description of what this does is documented here: https://caml.inria.fr/pub/docs/manual-ocaml/intfc.html

`glfwSwapBuffers` is a very expensive call - waiting for vsync to catch up, so for 60hz it could be ~16ms worst case. We should let other OCaml threads run during this time.