### PR TITLE
Bugfix: Remove noalloc on glfwSwapBuffers

### DIFF
--- a/src/glfw.re
+++ b/src/glfw.re
@@ -16,7 +16,6 @@ external glfwWindowShouldClose: Window.t => bool =
 
 external glfwPollEvents: unit => unit = "caml_glfwPollEvents";
 external glfwTerminate: unit => unit = "caml_glfwTerminate";
-[@noalloc]
 external glfwSwapBuffers: Window.t => unit = "caml_glfwSwapBuffers";
 external glfwSetWindowSize: (Window.t, int, int) => unit =
   "caml_glfwSetWindowSize";


### PR DESCRIPTION
PR #94 added `caml_release_runtime_system` and `caml_acquire_runtime_system` calls for performance (so that ocaml threads could be run in parallel with the swap buffers call). However, it turns out `[@noalloc]` is problematic with that, and caused an intermittent crash on startup. This addresses the issue by removing the `[@noalloc]` on `glfwSwapBuffers`.