### PR TITLE
Bugfix: Correct physical dimensions for JSOO

### DIFF
--- a/src/glfw_stubs.js
+++ b/src/glfw_stubs.js
@@ -146,9 +146,9 @@ function caml_glfwGetMonitorPos() {
 // Provides: caml_glfwGetMonitorPhysicalSize
 function caml_glfwGetMonitorPhysicalSize() {
   var win = joo_global_object.window;
-  var dpi = win.devicePixelRatio * 96;
-  var widthMM = win.innerWidth / (25.4 * dpi);
-  var heightMM = win.innerHeight / (25.4 * dpi);
+  var dpi = 96;
+  var widthMM = (win.innerWidth * 25.4) / dpi;
+  var heightMM = (win.innerHeight * 25.4) / dpi;
   return [0, widthMM, heightMM];
 };
 


### PR DESCRIPTION
We want the derived `dpi` to be 96 for our JSOO builds, but the scale calculations weren't quite correct - we were ending up with very large content scaling which caused problems with rendering.

The formula GLFW uses is:
```
const double dpi = mode->width / (widthMM / 25.4);
```

Solving for `widthMM` we get:
```
widthMM = (width * 25.4) / dpi
```

This corrects the equations to above.