### PR TITLE
API: Add glfw wait events for more efficient idling

### DIFF
--- a/examples/basic.re
+++ b/examples/basic.re
@@ -420,7 +420,7 @@ let run = () => {
     /* Run the GC so we can catch any GC-related crashes early! */
     Gc.full_major();
 
-    glfwPollEvents();
+    glfwWaitEventsTimeout(0.1);
     glfwWindowShouldClose(primaryWindow);
   });
 

--- a/examples/basic.re
+++ b/examples/basic.re
@@ -420,7 +420,8 @@ let run = () => {
     /* Run the GC so we can catch any GC-related crashes early! */
     Gc.full_major();
 
-    glfwWaitEventsTimeout(0.1);
+    glfwPollEvents();
+    /*glfwWaitEvents();*/
     glfwWindowShouldClose(primaryWindow);
   });
 

--- a/src/glfw.re
+++ b/src/glfw.re
@@ -33,6 +33,8 @@ external glfwWindowShouldClose: Window.t => bool =
   "caml_glfwWindowShouldClose";
 
 external glfwPollEvents: unit => unit = "caml_glfwPollEvents";
+external glfwWaitEvents: unit => unit = "caml_glfwWaitEvents";
+[@noalloc] external glfwWaitEventsTimeout: [@unboxed] float => unit = "caml_glfwWaitEventsTimeout";
 external glfwTerminate: unit => unit = "caml_glfwTerminate";
 external glfwSwapBuffers: Window.t => unit = "caml_glfwSwapBuffers";
 external glfwSetWindowSize: (Window.t, int, int) => unit =

--- a/src/glfw.re
+++ b/src/glfw.re
@@ -34,6 +34,7 @@ external glfwWindowShouldClose: Window.t => bool =
 
 external glfwPollEvents: unit => unit = "caml_glfwPollEvents";
 external glfwWaitEvents: unit => unit = "caml_glfwWaitEvents";
+external glfwPostEmptyEvent: unit => unit = "caml_glfwPostEventEvent";
 [@noalloc] external glfwWaitEventsTimeout: [@unboxed] float => unit = "caml_glfwWaitEventsTimeout";
 external glfwTerminate: unit => unit = "caml_glfwTerminate";
 external glfwSwapBuffers: Window.t => unit = "caml_glfwSwapBuffers";

--- a/src/glfw.re
+++ b/src/glfw.re
@@ -34,8 +34,8 @@ external glfwWindowShouldClose: Window.t => bool =
 
 external glfwPollEvents: unit => unit = "caml_glfwPollEvents";
 external glfwWaitEvents: unit => unit = "caml_glfwWaitEvents";
-external glfwPostEmptyEvent: unit => unit = "caml_glfwPostEventEvent";
-[@noalloc] external glfwWaitEventsTimeout: [@unboxed] float => unit = "caml_glfwWaitEventsTimeout";
+external glfwPostEmptyEvent: unit => unit = "caml_glfwPostEmptyEvent";
+external glfwWaitEventsTimeout: (float) => unit = "caml_glfwWaitEventsTimeout";
 external glfwTerminate: unit => unit = "caml_glfwTerminate";
 external glfwSwapBuffers: Window.t => unit = "caml_glfwSwapBuffers";
 external glfwSetWindowSize: (Window.t, int, int) => unit =

--- a/src/glfw.rei
+++ b/src/glfw.rei
@@ -10,6 +10,8 @@ let glfwCreateWindow:
 let glfwMakeContextCurrent: Window.t => unit;
 let glfwWindowShouldClose: Window.t => bool;
 let glfwPollEvents: unit => unit;
+let glfwWaitEvents: unit => unit;
+let glfwWaitEventsTimeout: float => unit;
 let glfwTerminate: unit => unit;
 let glfwSwapBuffers: Window.t => unit;
 let glfwSetWindowPos: (Window.t, int, int) => unit;

--- a/src/glfw.rei
+++ b/src/glfw.rei
@@ -10,6 +10,7 @@ let glfwCreateWindow:
 let glfwMakeContextCurrent: Window.t => unit;
 let glfwWindowShouldClose: Window.t => bool;
 let glfwPollEvents: unit => unit;
+let glfwPostEmptyEvent: unit => unit;
 let glfwWaitEvents: unit => unit;
 let glfwWaitEventsTimeout: float => unit;
 let glfwTerminate: unit => unit;

--- a/src/glfw_wrapper.cpp
+++ b/src/glfw_wrapper.cpp
@@ -756,6 +756,20 @@ extern "C" {
     }
 
     CAMLprim value
+    caml_glfwWaitEvents(value unit)
+    {
+        glfwWaitEvents();
+        return Val_unit;
+    }
+    
+    CAMLprim value
+    caml_glfwWaitEventsTimeout(double timeout)
+    {
+        glfwWaitEventsTimeout(timeout);
+        return Val_unit;
+    }
+
+    CAMLprim value
     caml_glfwSwapBuffers(value window)
     {
         WindowInfo *wd = (WindowInfo*)window;

--- a/src/glfw_wrapper.cpp
+++ b/src/glfw_wrapper.cpp
@@ -754,6 +754,13 @@ extern "C" {
         glfwPollEvents();
         return Val_unit;
     }
+    
+    CAMLprim value
+    caml_glfwPostEmptyEvent(value unit)
+    {
+        glfwPostEmptyEvent();
+        return Val_unit;
+    }
 
     CAMLprim value
     caml_glfwWaitEvents(value unit)

--- a/src/glfw_wrapper.cpp
+++ b/src/glfw_wrapper.cpp
@@ -751,29 +751,39 @@ extern "C" {
     CAMLprim value
     caml_glfwPollEvents(value unit)
     {
+        CAMLparam0();
+        caml_release_runtime_system();
         glfwPollEvents();
-        return Val_unit;
+        caml_acquire_runtime_system();
+        CAMLreturn(Val_unit);
     }
     
     CAMLprim value
     caml_glfwPostEmptyEvent(value unit)
     {
+        CAMLparam0();
         glfwPostEmptyEvent();
-        return Val_unit;
+        CAMLreturn(Val_unit);
     }
 
     CAMLprim value
     caml_glfwWaitEvents(value unit)
     {
+        CAMLparam0();
+        caml_release_runtime_system();
         glfwWaitEvents();
-        return Val_unit;
+        caml_acquire_runtime_system();
+        CAMLreturn(Val_unit);
     }
     
     CAMLprim value
-    caml_glfwWaitEventsTimeout(double timeout)
+    caml_glfwWaitEventsTimeout(value timeout)
     {
-        glfwWaitEventsTimeout(timeout);
-        return Val_unit;
+        CAMLparam1(timeout);
+        caml_release_runtime_system();
+        glfwWaitEventsTimeout(Double_val(timeout));
+        caml_acquire_runtime_system();
+        CAMLreturn(Val_unit);
     }
 
     CAMLprim value


### PR DESCRIPTION
This adds several additional APIs from GLFW that can help improve CPU usage on idle (by waiting on user input):

- `glfwWaitEvents()`
- `glfwWaitEventsTimeout()`
- `glfwPostEmptyEvent()`

We'll use this in Revery's idle mode to address https://github.com/onivim/oni2/issues/304
